### PR TITLE
Fix for high resolution screens

### DIFF
--- a/Editor/EditorUtilities.cs
+++ b/Editor/EditorUtilities.cs
@@ -148,13 +148,13 @@ namespace Animation_Player
 
         public static bool AreYouSureButton(string text, string areYouSureText, string uniqueID, float timeout, params GUILayoutOption[] options)
         {
-            if (areYouSureStyleNullGuard == null)
+            if (areYouSureStyleNullGuard == null || areYouSureStyle == null)
             {
                 /* Unity persists GUIStyle objects between assembly reloads, but fails to persist their data.
                  * So we need a object field to make sure the data's regenerated.
                  */
                 areYouSureStyleNullGuard = new object();
-                var buttonTexture = GetReadableCopyOf(GUI.skin.button.normal.background);
+                var buttonTexture = GUI.skin.button.normal == null ? GetReadableCopyOf(GUI.skin.button.normal.scaledBackgrounds[0]) : GetReadableCopyOf(GUI.skin.button.normal.background);
                 var pixels = buttonTexture.GetPixels();
                 for (var i = 0; i < pixels.Length; i++)
                     pixels[i] *= new Color(1f, 0f, 0f, 1f);

--- a/Editor/EditorUtilities.cs
+++ b/Editor/EditorUtilities.cs
@@ -154,7 +154,7 @@ namespace Animation_Player
                  * So we need a object field to make sure the data's regenerated.
                  */
                 areYouSureStyleNullGuard = new object();
-                var buttonTexture = GUI.skin.button.normal == null ? GetReadableCopyOf(GUI.skin.button.normal.scaledBackgrounds[0]) : GetReadableCopyOf(GUI.skin.button.normal.background);
+                var buttonTexture = GUI.skin.button.normal.background == null ? GetReadableCopyOf(GUI.skin.button.normal.scaledBackgrounds[0]) : GetReadableCopyOf(GUI.skin.button.normal.background);
                 var pixels = buttonTexture.GetPixels();
                 for (var i = 0; i < pixels.Length; i++)
                     pixels[i] *= new Color(1f, 0f, 0f, 1f);

--- a/Runtime/AnimationPlayerUpdater.cs
+++ b/Runtime/AnimationPlayerUpdater.cs
@@ -9,7 +9,11 @@ namespace Animation_Player {
 
         [RuntimeInitializeOnLoadMethod]
         public static void Initialize() {
+#if UNITY_2019_3_OR_NEWER
             PlayerLoopInterface.InsertSystemAfter(typeof(AnimationPlayerUpdater), Update, typeof(UnityEngine.PlayerLoop.Update));
+#else
+            PlayerLoopInterface.InsertSystemAfter(typeof(AnimationPlayerUpdater), Update, typeof(UnityEngine.Experimental.PlayerLoop.Update));
+#endif
         }
 
         private static void Update() {

--- a/Runtime/AnimationPlayerUpdater.cs
+++ b/Runtime/AnimationPlayerUpdater.cs
@@ -9,7 +9,7 @@ namespace Animation_Player {
 
         [RuntimeInitializeOnLoadMethod]
         public static void Initialize() {
-            PlayerLoopInterface.InsertSystemAfter(typeof(AnimationPlayerUpdater), Update, typeof(UnityEngine.Experimental.PlayerLoop.Update));
+            PlayerLoopInterface.InsertSystemAfter(typeof(AnimationPlayerUpdater), Update, typeof(UnityEngine.PlayerLoop.Update));
         }
 
         private static void Update() {


### PR DESCRIPTION
This is a fix where on high resolution screens the delete state button would not work due to GUI.skin.button.normal.background being null. Added a null check to use scaledBackgrounds instead.

Additionally Unity auto updated an obsolete API call.